### PR TITLE
Switch MathJax link to HTTPS

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -12,5 +12,5 @@ layout: default
 {% include footer.html %}
 
 <script type="text/javascript"
-    src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+    src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,6 +2,10 @@
 layout: page
 ---
 
+<script type="text/javascript"
+    src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+
 {% if page.image and page.headerImage %}
     <img class="title-image" src="{{ page.image }}" alt="{{ page.title }}">
 {% endif %}


### PR DESCRIPTION
This PR closes #5 by changing the link to the MathJax JS from HTTP to HTTPS. It also adds the MathJax JS link to the `post.html` layout in addition to the `page.html` layout.